### PR TITLE
Fix swapped API handlers

### DIFF
--- a/api/film.ts
+++ b/api/film.ts
@@ -1,12 +1,16 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { getWeeklySchedule } from "../backend/src/fetchSchedule";
+import { getMovieDetails } from "../backend/src/fetchScrape";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const queryUrl = Array.isArray(req.query.url) ? req.query.url[0] : req.query.url;
+  if (!queryUrl) {
+    return res.status(400).json({ error: "Paramètre url manquant." });
+  }
   try {
-    const schedule = await getWeeklySchedule();
-    res.status(200).json(schedule);
+    const details = await getMovieDetails(decodeURIComponent(queryUrl));
+    res.status(200).json(details);
   } catch (err: any) {
     console.error(err);
-    res.status(500).json({ error: "Erreur lors du scraping des horaires hebdomadaires." });
+    res.status(500).json({ error: "Erreur lors du scraping du détail du film." });
   }
 }

--- a/api/horaires.ts
+++ b/api/horaires.ts
@@ -1,16 +1,15 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { getMovieDetails } from "../backend/src/fetchScrape";
+import { getWeeklySchedule } from "../backend/src/fetchSchedule";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const queryUrl = Array.isArray(req.query.url) ? req.query.url[0] : req.query.url;
-  if (!queryUrl) {
-    return res.status(400).json({ error: "Paramètre url manquant." });
-  }
   try {
-    const details = await getMovieDetails(decodeURIComponent(queryUrl));
-    res.status(200).json(details);
+    const schedule = await getWeeklySchedule();
+    if (!schedule) {
+      return res.status(404).json({ error: "Aucun horaire trouvé." });
+    }
+    res.status(200).json(schedule);
   } catch (err: any) {
     console.error(err);
-    res.status(500).json({ error: "Erreur lors du scraping du détail du film." });
+    res.status(500).json({ error: "Erreur lors du scraping des horaires hebdomadaires." });
   }
 }


### PR DESCRIPTION
## Summary
- link `/api/film` handler to `getMovieDetails`
- return weekly schedule from `/api/horaires`

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6878e6c1a29483229a9cdfefb2828edd