### PR TITLE
Add env example and clarify API key usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+YOUTUBE_API_KEY=your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-error.log*
 # Environnements
 .env
 .env.*
+!/.env.example
 
 # OS-specific files
 .DS_Store

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,3 +44,9 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Environment Variables
+
+The `/api/semaine` endpoint relies on the YouTube Data API. On Vercel,
+set `YOUTUBE_API_KEY` in your project environment variables so this route
+can function correctly.


### PR DESCRIPTION
## Summary
- add `.env.example`
- allow `.env.example` in `.gitignore`
- document Vercel `YOUTUBE_API_KEY` requirement in README

## Testing
- `npm --prefix frontend test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6878e6c0f4d083228f13e4bc5058ebb2