### PR TITLE
Fix movie list issue on Vercel

### DIFF
--- a/backend/src/fetchScrape.ts
+++ b/backend/src/fetchScrape.ts
@@ -23,11 +23,8 @@ export interface DailyMovie {
   imageUrl: string;
 }
 
-// Vérification de la clé YouTube
+// Clé YouTube (optionnelle, permet le fallback bande-annonce)
 const YT_API_KEY = process.env.YOUTUBE_API_KEY;
-if (!YT_API_KEY) {
-  throw new Error("La variable YOUTUBE_API_KEY n'est pas définie dans .env");
-}
 
 const HEADERS = { headers: { "User-Agent": "Mozilla/5.0", "Accept-Language": "fr" } };
 const WEEK_URL = "https://www.cinemas-utopia.org/saintouen/index.php?mode=prochains";
@@ -72,7 +69,7 @@ export async function getMovieDetails(url: string): Promise<MovieDetails> {
   let videoSrc = $("video source").attr("src") || $("iframe").attr("src") || null;
 
   // Fallback YouTube si pas de trailer trouvé
-  if (!videoSrc) {
+  if (!videoSrc && YT_API_KEY) {
     try {
       const ytRes = await axios.get(YT_API_URL, {
         params: {


### PR DESCRIPTION
## Summary
- allow backend to run even if YOUTUBE_API_KEY is missing
- only request trailer from YouTube when API key is defined

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6878eff0352c83229ecd16ac72eef231